### PR TITLE
Point to the correct folder for the native distribution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,10 +16,6 @@ dependencies {
     implementation("org.jetbrains.compose.material3:material3:1.2.1")
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions.jvmTarget = "18"
-}
-
 compose.desktop {
     application {
         mainClass = "MainKt"
@@ -29,12 +25,12 @@ compose.desktop {
                 org.jetbrains.compose.desktop.application.dsl.TargetFormat.Dmg,
             )
             packageVersion = "1.0.0"
-            packageName = "theming"
+            packageName = "m3-components"
 
-            val iconsRoot = project.file("color-picker-desktop/src/main/resources")
+            val iconsRoot = project.file("src/main/resources")
 
             macOS {
-               iconFile.set(iconsRoot.resolve("icon.icns"))
+               iconFile.set(iconsRoot.resolve("app_icon.icns"))
             }
         }
     }


### PR DESCRIPTION
We need this in order to set the correct icon for the dmg distribution. Also removed the require JDK 18 part as we don't need this.

I think was wrong because of the folder structure when I copied the internal code over to this project.