### PR TITLE
Make dialog content bigger & scrollable 📺 (#9)

### DIFF
--- a/src/main/kotlin/ThemeColorPicker.kt
+++ b/src/main/kotlin/ThemeColorPicker.kt
@@ -1,13 +1,28 @@
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -16,6 +31,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import java.awt.Dimension
 
 @Composable
 internal fun ThemeColorPicker(
@@ -48,6 +64,8 @@ internal fun ThemeColorPicker(
         onCloseRequest = { isDialogVisible = false },
         title = colorName,
     ) {
+        window.size = Dimension(400, 400)
+
         ColorPickerDialogContent(
             currentColor,
             onOkClicked = { pickedColor ->
@@ -59,6 +77,7 @@ internal fun ThemeColorPicker(
         )
     }
 }
+
 @Composable
 private fun ColorPickerDialogContent(
     currentColor: Color,
@@ -67,9 +86,12 @@ private fun ColorPickerDialogContent(
     recentlyUsedColors: List<Color> = listOf(),
 ) {
     var pickedColor by remember { mutableStateOf(currentColor) }
+    val scrollState = rememberScrollState()
 
     Column(
-        modifier = modifier.fillMaxSize().padding(16.dp),
+        modifier = modifier.fillMaxSize()
+            .padding(16.dp)
+            .verticalScroll(scrollState),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Box(


### PR DESCRIPTION
Currently, dialog content is not scrollable which is annoying. Also, updated the default size of the dialog so that its a bit bigger.  

Resolves: #9 


https://user-images.githubusercontent.com/38246678/218340161-ba06d666-d409-4b75-a0c9-40a9bd4ed5eb.mp4