### PR TITLE
Prepare for release 1.1.0 ☺️ 🐰 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
             targetFormats(
                 org.jetbrains.compose.desktop.application.dsl.TargetFormat.Dmg,
             )
-            packageVersion = "1.0.0"
+            packageVersion = "1.1.0"
             packageName = "m3-components"
 
             val iconsRoot = project.file("src/main/resources")


### PR DESCRIPTION
Bumping the version code to '1.1.0