### PR TITLE
Export both dark and light color schemes

### DIFF
--- a/src/main/kotlin/FileUtils.kt
+++ b/src/main/kotlin/FileUtils.kt
@@ -35,57 +35,78 @@ internal fun FileChooserDialog(
 }
 
 internal fun saveColorsToFile(
-    currentColorPalette: ColorScheme,
+    lightColorPalette: ColorScheme,
+    darkColorPalette: ColorScheme,
     file: File,
     fileType: ColorFileType,
     onResult: (success: Boolean, message: String) -> Unit
 ) {
     when (fileType) {
-        Kotlin -> saveColorsToKotlinFile(file = file, currentColorPalette = currentColorPalette, onResult = onResult)
-        XML -> saveColorsToXMLFile(file = file, currentColorPalette = currentColorPalette, onResult = onResult)
+        Kotlin -> saveColorsToKotlinFile(file = file, lightColorPalette = lightColorPalette, darkColorPalette = darkColorPalette, onResult = onResult)
+        XML -> saveColorsToXMLFile(file = file, lightColorPalette = lightColorPalette, darkColorPalette = darkColorPalette, onResult = onResult)
     }
 }
 
 private fun saveColorsToXMLFile(
     file: File,
-    currentColorPalette: ColorScheme,
+    lightColorPalette: ColorScheme,
+    darkColorPalette: ColorScheme,
     onResult: (success: Boolean, message: String) -> Unit
 ) {
     tryWriteToFile(
         onResult = onResult
     ) {
         val path = file.path
-        val outputFile = Path(path, "colors.xml").createFile().toFile()
-        outputFile.apply {
 
-            getColorList(colorPalette = currentColorPalette).forEach { color ->
+        // Light colors
+        val lightOutputFile = Path(path, "light_colors.xml").createFile().toFile()
+        lightOutputFile.apply {
+            getColorList(colorPalette = lightColorPalette).forEach { color ->
                 appendText(getColorsXMLProperty(colorNameLowerCase = color.key, color = color.value))
             }
-
         }
-        onResult(true, "Saving colors worked")
+
+        // Dark colors
+        val darkOutputFile = Path(path, "dark_colors.xml").createFile().toFile()
+        darkOutputFile.apply {
+            getColorList(colorPalette = darkColorPalette).forEach { color ->
+                appendText(getColorsXMLProperty(colorNameLowerCase = color.key, color = color.value))
+            }
+        }
+
+        onResult(true, "Saved light_colors.xml and dark_colors.xml")
     }
 }
 
 
 private fun saveColorsToKotlinFile(
     file: File,
-    currentColorPalette: ColorScheme,
+    lightColorPalette: ColorScheme,
+    darkColorPalette: ColorScheme,
     onResult: (success: Boolean, message: String) -> Unit
 ) {
     tryWriteToFile(
         onResult = onResult
     ) {
         val path = file.path
-        val outputFile = Path(path, "colors.kt").createFile().toFile()
-        outputFile.apply {
 
-            getColorList(colorPalette = currentColorPalette).forEach { color ->
+        // Light colors
+        val lightOutputFile = Path(path, "LightColors.kt").createFile().toFile()
+        lightOutputFile.apply {
+            getColorList(colorPalette = lightColorPalette).forEach { color ->
                 appendText(getColorKotlinProperty(colorNameLowerCase = color.key, color = color.value))
             }
-
         }
-        onResult(true, "Saving colors worked")
+
+        // Dark colors
+        val darkOutputFile = Path(path, "DarkColors.kt").createFile().toFile()
+        darkOutputFile.apply {
+            getColorList(colorPalette = darkColorPalette).forEach { color ->
+                appendText(getColorKotlinProperty(colorNameLowerCase = color.key, color = color.value))
+            }
+        }
+
+        onResult(true, "Saved LightColors.kt and DarkColors.kt")
     }
 }
 private fun tryWriteToFile(

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -136,7 +136,10 @@ internal fun Material3Playground(darkmode: Boolean) {
                     title = "Select directory to save file",
                     onResult = {
                         saveColorsToFile(
-                            currentColorPalette, file = it, onResult = { success, message ->
+                            lightColorPalette = lightColorScheme,
+                            darkColorPalette = darkColorScheme,
+                            file = it,
+                            onResult = { success, message ->
                                 // Implement success / failure screens for this when VM is implemented,
                                 // and we can easier manage states.
                                 fileSaverDialog = message
@@ -153,8 +156,8 @@ internal fun Material3Playground(darkmode: Boolean) {
 
             if (fileSaverDialog != null) {
                 val title = when (savableFileType) {
-                    Kotlin -> "Saving Colors to Colors.kt"
-                    XML -> "Saving Colors to Colors.xml"
+                    Kotlin -> "Saving Colors to LightColors.kt and DarkColors.kt"
+                    XML -> "Saving Colors to light_colors.xml and dark_colors.xml"
                 }
                 AlertDialog(
                     modifier = Modifier.defaultMinSize(minWidth = 400.dp, minHeight = 150.dp)


### PR DESCRIPTION
## Summary

This PR updates the color export functionality to always export both light and dark theme colors as separate files.

## Changes

### FileUtils.kt
- Updated `saveColorsToFile()` to accept both `lightColorPalette` and `darkColorPalette`
- XML export now creates:
  - `light_colors.xml` - light theme colors
  - `dark_colors.xml` - dark theme colors
- Kotlin export now creates:
  - `LightColors.kt` - light theme colors  
  - `DarkColors.kt` - dark theme colors
- Updated success messages to reflect both files being saved

### Main.kt
- Updated the call to `saveColorsToFile()` to pass both color schemes
- Updated dialog titles to show both file names

## Testing
- Compilation verified ✓
- Existing tests pass ✓

Resolves #21